### PR TITLE
Add support for view event payloads

### DIFF
--- a/src/slackers/models.py
+++ b/src/slackers/models.py
@@ -32,6 +32,7 @@ class SlackAction(SlackBase):
     channel: dict = None
     team: dict = None
     actions: list = None
+    view: dict = None
 
 
 class SlackCommand(SlackBase):

--- a/src/slackers/server.py
+++ b/src/slackers/server.py
@@ -52,6 +52,10 @@ async def post_actions(request: Request):
     if action.callback_id:
         event_type = f"{action.type}:{action.callback_id}"
         emit(actions, event_type, action)
+    elif action.view:
+        if action.view.callback_id:
+            event_type = f"{action.type}:{action.view.callback_id}"
+            emit(actions, event_type, action)
     return Response()
 
 

--- a/tests/actions.py
+++ b/tests/actions.py
@@ -21,6 +21,7 @@ def message_action():
         "channel": {"id": "CHANNEL_ID", "name": "CHANNEL_NAME"},
         "team": {"id": "TEAM_ID", "domain": "TEAM_DOMAIN"},
         "actions": [],
+        "view": {},
     }
 
 
@@ -37,6 +38,7 @@ def block_action():
         "channel": {"id": "CHANNEL_ID", "name": "CHANNEL_NAME"},
         "team": {"id": "TEAM_ID", "domain": "TEAM_DOMAIN"},
         "actions": [{"action_id": "ACTION_ID_1"}, {"action_id": "ACTION_ID_2"}],
+        "view": {},
     }
 
 


### PR DESCRIPTION
Hi @uhavin!

First of all, this is a great utility library, so keep up the good work! Just to let you know, I have been using it for my Slack bot to keep my Python code neat (decorators ftw!).

Back to this PR. So far, view payloads would be directed to the `/actions` endpoint as well since Slack mentioned [here](https://api.slack.com/interactivity/handling#preparing_your_app_for_user_interactions) that view payloads would be directed to the same Request URL as interactive components and app actions. However, since the `SlackAction` Pydantic model that you have defined did not specify any `view` blocks, it was simply discarded.

This PR fixes this issue by adding support for a `view` dictionary in the `SlackAction` Pydantic model. This also allows specifying a particular view payload's `callback_id` to listen to.

Cheers!