### PR TITLE
Remove a duplicate attribute

### DIFF
--- a/src/slackers/models.py
+++ b/src/slackers/models.py
@@ -44,7 +44,6 @@ class SlackAction(SlackBase):
 
 
 class SlackCommand(SlackBase):
-    user_id: str
     command: str
     response_url: str
     trigger_id: str


### PR DESCRIPTION
Attribute `user_id` of `SlackCommand` is duplicated.