### PR TITLE
Add text attribute to command model

### DIFF
--- a/src/slackers/models.py
+++ b/src/slackers/models.py
@@ -51,3 +51,4 @@ class SlackCommand(SlackBase):
     user_name: str
     team_id: str
     channel_id: str
+    text: str

--- a/tests/slash_command.py
+++ b/tests/slash_command.py
@@ -24,6 +24,7 @@ def post_commands_should_emit_commands_event_with_payload(
         "user_name": "USER_NAME",
         "team_id": "TEAM_ID",
         "channel_id": "CHANNEL_ID",
+        "text": "hello from slack"
     }
 
     response = client.post(url="/commands", data=command, headers=test_headers)


### PR DESCRIPTION
Currently the text passed along with a Slash command is stripped out by Pydantic. Adding this allows you to use `/command some random message`.

I tested this locally and it doesn't matter if no text is passed along in the command since Slack always passes this key in the payload.