### PR TITLE
authed_users changed to Optional for app_home_opened events

### DIFF
--- a/src/slackers/models.py
+++ b/src/slackers/models.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -17,7 +17,7 @@ class SlackEnvelope(SlackBase):
     api_app_id: str
     event: dict
     type: str
-    authed_users: List[str]
+    authed_users: Optional[List[str]]
     event_id: str
     event_time: int
 


### PR DESCRIPTION
Slack's `app_home_opened` event currently is missing the field `authed_users`. Making `authed_users` optional prevents `422 Unprocessable Entity` errors when `app_home_event` is received by slackers.